### PR TITLE
update from default site meta config and logo alt

### DIFF
--- a/docs/_data/site.cjs
+++ b/docs/_data/site.cjs
@@ -3,7 +3,7 @@ module.exports = function () {
     dir: 'ltr',
     lang: 'en',
     name: 'WC Community Group',
-    description: 'Rocket is the way to build fast static websites with a sprinkle of JavaScript',
+    description: 'Collect and share documentation and guides for web component best practices',
     socialLinks: [
       {
         name: 'GitHub',
@@ -13,7 +13,7 @@ module.exports = function () {
     gitSiteUrl: 'https://github.com/webcomponents-cg/docs-and-guides',
     gitBranch: 'master',
     helpUrl: 'https://github.com/webcomponents-cg/docs-and-guides/issues',
-    logoAlt: 'Rocket Logo',
+    logoAlt: 'WC-CG Logo',
     iconColorMaskIcon: '#3f93ce',
     iconColorMsapplicationTileColor: '#1d3557',
     iconColorThemeColor: '#1d3557',


### PR DESCRIPTION
Noticed the site's `<meta>` description tag and `logoAlt` were the Rocket defaults.
```html
<meta name="description" content="Rocket is the way to build fast static websites with a sprinkle of JavaScript">
<meta property="og:description" content="Rocket is the way to build fast static websites with a sprinkle of JavaScript">
```

  Grabbed the description content from the README.