### PR TITLE
Add initial content outline

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,5 @@
+# Docs and Guide Plan
+
+This folder exists to capture the current docs plans in a central place where changes to the plans can be reviewed in PRs.
+
+[Outline](./outline.md)

--- a/plan/outline.md
+++ b/plan/outline.md
@@ -59,7 +59,7 @@
     * Responding to attribute changes (`attributeChangedCallback`)
     * Responding to property changes (accessors)
     * Considerations about when to use methods
-    * Reflecting properties to attributes
+    * Reflecting between properties and attributes
     * Using events for data
   * Publishing to npm
   * Composition

--- a/plan/outline.md
+++ b/plan/outline.md
@@ -1,0 +1,73 @@
+# Docs Outline
+
+* What are web components
+  * Custom Elements
+  * Shadow DOM
+  * Standard JS Modules
+* Why web components
+  * What do we mean by interop?
+    * Interop with HTML, frameworks, the browser
+    * Interop with file formats: Markdown vs MDX, etc.
+    * Interoperable composition with slots
+    * Interop with the future
+  * Use cases
+    * Standalone components
+    * Component sets and design systems
+    * Applications
+* Related specs
+  * MDN links
+  * GitHub repos with proposals
+  * What's left, ie. WCCG reports
+* Using web components
+  * Basics
+    * Definining, the custom element registry, and the single tag name scope
+    * Upgrading, and `:defined`
+    * Children and slots
+    * Events
+  * Using web components in HTML and vanilla JS
+  * Styling
+    * CSS Custom Properties
+    * ::part()s
+  * Using web components with frameworks
+  * Using web components in...
+    * Markdown (how to import in various systems)
+    * WordPress
+* Writing web components
+  * Defining
+    * Custom element registries
+    * Self-registering vs not
+    * Defensive registration for special cases (CDN distribution)
+  * Lifecycle
+    * Basics: `observedAttributes`, `constructor`, `attributeChangedCallback`...
+    * Cleaning up resources in `disconnectedCallback`
+  * Shadow DOM
+    * attachShadow()
+    * open vs closed
+    * Encapsulation: DOM, events, CSS
+      * Just overview: more detail in Styling and Composition sections
+    * Slots
+  * Styling
+    * Encapsulation (more detail than)
+    * Shadow selectors: `:host`, `:host()`, and `::slotted()`
+    * CSS Custom Properties
+    * CSS Shadow Parts: `part` and `::part()`
+    * Constructible style sheets
+    * Theming
+      * Strategies for deep styling
+  * Dealing with data
+    * Making reactive properties with accessors
+    * Reflecting properties to attributes
+    * Using events for data
+  * Publishing to npm
+  * Composition
+    * Slots
+    * Communicating with events
+    * Using children
+  * Accessibility
+  * Forms
+  * Web component libraries
+* Community Protocols
+* Community and Resources
+* FAQ
+  * Myth-busting answers can go here ("can custom elements really only take strings?", etc)
+* Demos and Playgrounds (standalone or to accompany each piece of content?)

--- a/plan/outline.md
+++ b/plan/outline.md
@@ -69,5 +69,9 @@
 * Community Protocols
 * Community and Resources
 * FAQ
-  * Myth-busting answers can go here ("can custom elements really only take strings?", etc)
+  * Myth-busting answers can go here
+    * Can custom elements really only take strings?
+    * Is it impossible to SSR web components?
+    * Why don't web components solve ___ that other frameworks do?
+    * ...
 * Demos and Playgrounds (standalone or to accompany each piece of content?)

--- a/plan/outline.md
+++ b/plan/outline.md
@@ -55,7 +55,10 @@
     * Theming
       * Strategies for deep styling
   * Dealing with data
-    * Making reactive properties with accessors
+    * Designing both a property & attribute API
+    * Responding to attribute changes (`attributeChangedCallback`)
+    * Responding to property changes (accessors)
+    * Considerations about when to use methods
     * Reflecting properties to attributes
     * Using events for data
   * Publishing to npm


### PR DESCRIPTION
Fixes #13 

This is preliminary - I added a bunch of sections I thought reasonable, but it's all up for changes.

I think we should emphasize that the outline is a living document and probably spend some amount of time massaging it here, but not try to get it perfect right away and iterate in PRs.

We should probably also add a note about our intended workflow: like if you pick a page to write, make an issue and link to it from the outline? We could also proactively make a bunch of issues, but that might require more synchronization work as the outline changes. Once we get content in place, if we make a change to the outline we'll want to know where it's out of sync and needs content changes to bring it into sync - or, once we get enough content we retire this document in favor of the actual content structure.