### PR TITLE
Chore/site structure outline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ The first step for any substantive contribution is to either:
 Issues are where individual reports and Community Group discussions come together such
 that the eventual consensus can be turned into official language.
 
+> **Note** _For additional context around content and outlining, please see the [plan/](./plan/) directory for more information about our information architecture._
+
 ## Goals and Non-Goals
 
 The main goal of the Web Components Community Group docs-and-guides effort is to provide explanation, advocacy, and documentation of shared web components concepts in a common location that is not tied to any specific web components library.

--- a/plan/site-structure.md
+++ b/plan/site-structure.md
@@ -1,0 +1,9 @@
+# Site Structure
+
+The below aims to capture the top level site and navigation structure for the documentation site we have in mind.  You can find more in depth material related to these sections in this _plan/_ folder on a per section basis.
+
+1. _/ (Home)_ - Would include featured items, showcase community highlights
+1. _/catalog_ - Showcasing a curation of web components 
+1. [_/docs_](./outline.md) - Technical content related to authoring and using Web Components
+1. _/articles_ - Opinionated content from contributing authors about Web Components and the ecosystem at large
+1. _/about_ - Meta information about the group, how to contribute and get involved


### PR DESCRIPTION
Coming out of our last meeting, and building off feedback from https://github.com/webcomponents-cg/docs-and-guides/pull/27#discussion_r879542118, plus taking into account #34

1. Created a _plan/site-structure.md_ with top level nav and sections with brief description
1. Made a note of the _plan/_ directory in the CONTRIBUTING.md